### PR TITLE
Run wal on background change and use system sassc

### DIFF
--- a/material-you-theme@asubbiah.com/extension.js
+++ b/material-you-theme@asubbiah.com/extension.js
@@ -152,6 +152,7 @@ function apply_theme(base_presets, color_mappings, notify=false) {
     let css = "";
     for (const key in base_preset.variables) {
         css += "@define-color " + key + " " + base_preset.variables[key] + ";\n"
+        if (key === "window_bg_color") run_pywal(base_preset.variables[key], wall_path)
     }
     for (const prefix_key in base_preset.palette) {
         for (const key_2 in base_preset.palette[prefix_key]) {
@@ -165,7 +166,7 @@ function apply_theme(base_presets, color_mappings, notify=false) {
     write_str(css, config_path + "/gtk-4.0/gtk.css");
     write_str(css, config_path + "/gtk-3.0/gtk.css");
 
-    if (ext_utils.check_npm()) {
+    if (ext_utils.check_bin('/usr/bin/sassc')) {
         const version = Config.PACKAGE_VERSION.substring(0, 2);
 
         modify_colors(
@@ -381,4 +382,16 @@ function map_colors(color_mapping, base_preset, scheme) {
         }
     }
     return base_preset;
+}
+
+function run_pywal(background, image) {
+    if(!ext_utils.check_bin('/usr/bin/wal')) return
+    try {
+        Gio.Subprocess.new(
+            ['/usr/bin/wal', '-b', background, '-i', image],
+            Gio.SubprocessFlags.NONE
+        );
+    } catch (e) {
+        logError(e);
+    }
 }

--- a/material-you-theme@asubbiah.com/utils/ext_utils.js
+++ b/material-you-theme@asubbiah.com/utils/ext_utils.js
@@ -3,7 +3,7 @@ const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
 const EXTENSIONDIR = Me.dir.get_path();
 
-function check_npm() {
-    const file = Gio.File.new_for_path(EXTENSIONDIR + "/node_modules/sass/sass.js");
+function check_bin(path) {
+    const file = Gio.File.new_for_path(path);
     return file.query_exists(null);
 }


### PR DESCRIPTION
Had a few issues getting the tweak to work with the sass installation button, I made it so it uses system-wide sassc and also added automatic run of pywal whenever background changes since pywal color schemes are supported by a handful of applications. Attaching screenshot of what kind of themes could these changes enable
![pywall-gnome](https://user-images.githubusercontent.com/20412235/190525171-81bf3674-da18-439e-a083-8a61f81d3e5c.png)
